### PR TITLE
Made some adjustments to the wording of the JS dev job spec.

### DIFF
--- a/Recruitment/JobSpecs/why_you_js_engineer.md
+++ b/Recruitment/JobSpecs/why_you_js_engineer.md
@@ -1,16 +1,16 @@
 ### What you'll do
-* Work intimately with clients to understand their organisation, aspirations and challenges.
+* Understand clients' organisations, aspirations and challenges.
 * Help clients identify promising solutions through participating in, and leading, digital workshops.
 * Build real solutions through experimentation as part of a multi-faceted team.  
 * Accelerate and improve how we help our clients through developing and contributing to components, services and methodologies.
 * Explore up-and-coming technologies and software products; seize learning and knowledge sharing opportunities; participate in professional organizations. Read; teach; learn.
 
 
-### Who fits this role
-* Talented and passionate JavaScript Engineers, handling both server-side and client-side code.
-* Excellent ES2016/ESNext/HTML/CSS skills, comfortable using modern frameworks to develop single page applications.
-* Keen to learn and keep up with new technologies, transcending current crazes and trendy tools/frameworks.
+### What you'll need
+* A passion and talent for JavaScript development, handling both server-side and client-side code.
+* Excellent ES2016/ESNext, HTML & CSS skills, comfortable using modern frameworks to develop single page applications.
+* A desire to learn and keep up with new technologies that transcends current crazes and trendy tools or frameworks.
 * Effective communication skills, both written and verbal for technical and non-technical audiences.
-* Experience in working with UX/designers to build exciting UIs for web applications.
+* Experience of working with UX teams to jointly craft UIs that are both exciting and fit for purpose.
 * Deep understanding of what motivates, inspires and stifles software teams.
 * Experience with agile methods, along with having found their limitations and ways to overcome them.


### PR DESCRIPTION
- Changed first point under "What you'll do" so that all points read like actions: "Understand", "Help", "Build", etc..
- Renamed "Who fits this role" to "What you'll need" so that it fits better with "What you'll do". Tweaked wording of some points below so that they sound better when following the statement "What you'll do..."
- Changed point about working with UX peeps 
