### PR TITLE
Add devops engineer exercise

### DIFF
--- a/Recruitment/Exercises/devops_engineer.md
+++ b/Recruitment/Exercises/devops_engineer.md
@@ -7,8 +7,8 @@ Docker) or use any CI service, provisioning tool and cloud environment you feel 
 
 For this test, you will need to deploy our [example application](https://github.com/buildit/devops-test-webapp).
 
-* Your CI job should:
-  * Run when a feature branch is pushed to Github. If you are working locally feel free to use some other method for triggering your build.
+* Your CI job(s) should:
+  * Run the tests included with the application.
   * Deploy to a target environment when the job is successful.
 * The target environment should consist of:
   * A load-balancer accessible via HTTP on port 80.

--- a/Recruitment/Exercises/devops_engineer.md
+++ b/Recruitment/Exercises/devops_engineer.md
@@ -1,23 +1,23 @@
 # DevOps Engineer - Technical Test
 We think infrastructure is best represented as code, and provisioning of resources should be automated as much as possible.
 
-Your task is to create a CI build pipeline that deploys a web application to a load-balanced
-environment. You are free to complete the test in a local environment (using tools like Vagrant and
-Docker) or use any CI service, provisioning tool and cloud environment you feel comfortable with.
+Your task is to create a clustered web environment. You are free to complete the test using:
 
-For this test, you will need to deploy our [example application](https://github.com/buildit/devops-test-webapp).
+* A local development environment, using tools like Vagrant and Docker.
+* A cloud environment, using any provider and provisioning tools you feel comfortable with.
 
-* Your CI job(s) should:
-  * Run the tests included with the application.
-  * Deploy to a target environment when the job is successful.
-* The target environment should consist of:
-  * A load-balancer accessible via HTTP on port 80.
-  * Two application servers ([example application](https://github.com/buildit/devops-test-webapp)) accessible via HTTP on port 3000.
+The target environment should consist of:
+
+* A load-balancer accessible via HTTP on port 80.
+* Two application servers accessible via HTTP on port 3000 - please use our provided [example application](https://github.com/buildit/devops-test-webapp).
 * The load-balancer should use a round-robin strategy.
 * The application server should return the response "Hi there! I'm being served from {hostname}!".
 
 ## Context
 We are testing your ability to implement modern automated infrastructure, as well as general knowledge of system administration. In your solution you should emphasize readability, maintainability and DevOps methodologies.
+
+## Bonus Point
+Automate a build and delivery pipeline using the [example application](https://github.com/buildit/devops-test-webapp)
 
 ## Submit your solution
 Create a public Github repository and push your solution in it. Commit often - we would rather see a history of trial and error than a single monolithic push. When you're finished, send us the URL to the repository.

--- a/Recruitment/Exercises/devops_engineer.md
+++ b/Recruitment/Exercises/devops_engineer.md
@@ -3,8 +3,7 @@ We think infrastructure is best represented as code, and provisioning of resourc
 
 Your task is to create a CI build pipeline that deploys a web application to a load-balanced
 environment. You are free to complete the test in a local environment (using tools like Vagrant and
-Docker) or use any CI service, provisioning tool and cloud environment you feel comfortable with (we
-recommend creating a free tier account so you don't incur any costs).
+Docker) or use any CI service, provisioning tool and cloud environment you feel comfortable with.
 
 For this test, you will need to deploy our [example application](https://github.com/buildit/devops-test-webapp).
 

--- a/Recruitment/Exercises/devops_engineer.md
+++ b/Recruitment/Exercises/devops_engineer.md
@@ -1,0 +1,25 @@
+# DevOps Engineer - Technical Test
+We think infrastructure is best represented as code, and provisioning of resources should be automated as much as possible.
+
+Your task is to create a CI build pipeline that deploys a web application to a load-balanced
+environment. You are free to complete the test in a local environment (using tools like Vagrant and
+Docker) or use any CI service, provisioning tool and cloud environment you feel comfortable with (we
+recommend creating a free tier account so you don't incur any costs).
+
+For this test, you will need to deploy our [example application](https://github.com/buildit/devops-test-webapp).
+
+* Your CI job should:
+  * Run when a feature branch is pushed to Github. If you are working locally feel free to use some other method for triggering your build.
+  * Deploy to a target environment when the job is successful.
+* The target environment should consist of:
+  * A load-balancer accessible via HTTP on port 80.
+  * Two application servers ([example application](https://github.com/buildit/devops-test-webapp)) accessible via HTTP on port 3000.
+* The load-balancer should use a round-robin strategy.
+* The application server should return the response "Hi there! I'm being served from {hostname}!".
+
+## Context
+We are testing your ability to implement modern automated infrastructure, as well as general knowledge of system administration. In your solution you should emphasize readability, maintainability and DevOps methodologies.
+
+## Submit your solution
+Create a public Github repository and push your solution in it. Commit often - we would rather see a history of trial and error than a single monolithic push. When you're finished, send us the URL to the repository.
+


### PR DESCRIPTION
Upon consideration - I have removed the requirement for a build and deploy pipeline (that has become optional - bonus point).

My rationale is:

- if we cannot reimburse for cloud costs incurred - then doing the test in a local environment should be a straightforward experience
- if the candidate is running locally - it makes using a CI service improbable
- if a CI service is improbable, then (in all likelihood) it means upping a Jenkins instance and automating a Jenkins 2 pipeline

In addition to creating a clustered environment, I think this is too much to ask a candidate to undertake for a technical test.

 